### PR TITLE
fix formatting issues related to brewcask breakage

### DIFF
--- a/lib/puppet/provider/package/brew.rb
+++ b/lib/puppet/provider/package/brew.rb
@@ -6,7 +6,8 @@ Puppet::Type.type(:package).provide(:brew,
   def install
     name = install_name
     output = execute([command(:brew), :install, name, *install_options])
-    if output =~ /Error: No available formula/
+
+    if output =~ /Searching taps/
       raise Puppet::ExecutionFailure, "Could not find package #{name}"
     end
   end


### PR DESCRIPTION
Fixes #2. Issues were as follows:

- `execute` command doesn't give full output, only stdout, so some result parsing was incorrect.
- brewcask added non-standard character output (beer emoji on success) that fucked with parsing/encoding.
- Missing `result[name] ?  : ' '` in brewcask provider caused it to behave differently than homebrew provider.

Thanks to @jordigg for helping track this down.