### PR TITLE
fix #17 - properly set custom facts

### DIFF
--- a/lib/facter/has_brew.rb
+++ b/lib/facter/has_brew.rb
@@ -1,13 +1,13 @@
 Facter.add(:has_brew) do
   setcode do
-    warn('Unsupported OS.')
-    nil
+    err('This Module works on Mac OS X only!')
+    "nil"
   end
 end
 
 Facter.add(:has_brew) do
   confine :operatingsystem => :darwin
   setcode do
-    File.exists?('/usr/local/bin/brew') || system('brew --version >/dev/null 2>&1')
+    File.exists?('/usr/local/bin/brew') or system('brew --version >/dev/null 2>&1') ? "true" : "false"
   end
 end

--- a/lib/facter/has_compiler.rb
+++ b/lib/facter/has_compiler.rb
@@ -1,14 +1,14 @@
 Facter.add(:has_compiler) do
   setcode do
-    warn('Unsupported OS.')
-    nil
+    err('This Module works on Mac OS X only!')
+    "nil"
   end
 end
 
 Facter.add(:has_compiler) do
   confine :operatingsystem => :darwin
   setcode do
-    File.exists?('/usr/bin/cc') || system('/usr/bin/xcrun -find cc >/dev/null 2>&1')
+    File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1') ? "true" : "false"
   end
 end
 
@@ -17,6 +17,6 @@ Facter.add(:has_compiler) do
   confine :operatingsystem => :darwin, :macosx_productversion_major => '10.9'
   setcode do
     (File.exists?('/Applications/Xcode.app') or File.exists?('/Library/Developer/CommandLineTools/')) and
-    (File.exists?('/usr/bin/cc') || system('/usr/bin/xcrun -find cc >/dev/null 2>&1'))
+        (File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1')) ? "true" : "false"
   end
 end

--- a/manifests/compiler.pp
+++ b/manifests/compiler.pp
@@ -1,24 +1,19 @@
 class homebrew::compiler {
 
-  if $::has_compiler == true {
+  if $::has_compiler == "true" {
   } elsif versioncmp($::macosx_productversion_major, '10.7') < 0 {
     warning('Please install the Command Line Tools bundled with XCode manually!')
-  } else {
+  } elsif ($homebrew::command_line_tools_package and $homebrew::command_line_tools_source) {
 
-    if ($homebrew::command_line_tools_package and $homebrew::command_line_tools_source) {
+    notice('Installing Command Line Tools.')
 
-      notice('Installing Command Line Tools.')
-
-      package { $homebrew::command_line_tools_package:
-        ensure   => present,
-        provider => pkgdmg,
-        source   => $homebrew::command_line_tools_source,
-      }
-
-    } else {
-      warning('No Command Line Tools detected and no download source set. If Command Line Tools is installed, this may be a false positive. If not, please set download sources or install manually.')
+    package { $homebrew::command_line_tools_package:
+      ensure   => present,
+      provider => pkgdmg,
+      source   => $homebrew::command_line_tools_source,
     }
-
+  } else {
+    warning('No Command Line Tools detected and no download source set. If Command Line Tools is installed, this may be a false positive. If not, please set download sources or install manually.')
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,7 @@ class homebrew (
   $command_line_tools_source  = undef,
   $user                       = 'root'
 ) {
+
   if $::operatingsystem != 'Darwin' {
     err('This Module works on Mac OS X only!')
     fail('Exit')


### PR DESCRIPTION
Some OS/puppet/facter combinations don't properly encode facts as
booleans. To side-step this problem for better compatibility, use
strings over booleans all the time. `"true"` and `"false"` are ugly
things to see anywhere, but it can't be helped.