### PR TITLE
Move to parse stdout only

### DIFF
--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -41,15 +41,10 @@ Puppet::Type.type(:package).provide(:brewcask,
   def self.package_list(options={})
     Puppet.debug "Listing installed packages"
     begin
-      result = execute([command(:brew), :cask, :list, '--versions'])
-      result = "" if result.include?("Warning: nothing to list")
       if name = options[:justme]
-        # Of course brew-cask has a different --versions format than brew when
-        # getting the version of a single package
-        unless result.empty?
-          result = Hash[result.lines.map {|line| line.split}]
-          result = result[name] ? name + ' ' + result[name] : ''
-        end
+        result = execute([command(:brew), :cask, :list, '--versions', name])
+      else
+        result = execute([command(:brew), :list, '--versions'])
       end
       Puppet.debug "Found packages #{result}"
       list = result.lines.map {|line| name_version_split(line)}

--- a/lib/puppet/provider/package/brewcommon.rb
+++ b/lib/puppet/provider/package/brewcommon.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:package).provide(:brewcommon,
 
     warn('Homebrew will be dropping support for root-owned homebrew by November 2016. Though this module will not prevent you from running homebrew as root, you may run into unexpected issues. Please migrate your installation to a user account -- this module will enforce this once homebrew has officially dropped support for root-owned installations.') if owner == 0
 
-    super(cmd, :uid => owner, :gid => group, :combine => true,
+    super(cmd, :uid => owner, :gid => group, :combine => false,
           :custom_environment => { 'HOME' => home })
   end
 

--- a/lib/puppet/provider/package/homebrew.rb
+++ b/lib/puppet/provider/package/homebrew.rb
@@ -50,13 +50,7 @@ Puppet::Type.type(:package).provide(:homebrew,
       if name = options[:justme]
         result = execute([command(:brew), :list, '--versions', name])
         unless result.include? name
-          # Of course brew-cask has a different --versions format than brew
-          # when getting the version of a single package
-          result = execute([command(:brew), :cask, :list, '--versions'])
-          unless result.empty?
-            result = Hash[result.lines.map {|line| line.split}]
-            result = result[name] ? name + ' ' + result[name] : ''
-          end
+          result += execute([command(:brew), :cask, :list, '--versions', name])
         end
       else
         result = execute([command(:brew), :list, '--versions'])


### PR DESCRIPTION
PR to move away from stdout + sterr which causes many headaches when parsing outputs which change constantly and break the module as we recognise it as error instead of warnings.