### PR TITLE
fix #44 - only manage permissions for /usr/local/Homebrew

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,20 +1,21 @@
 class homebrew::install {
 
-  file { ['/usr/local', '/Library/Caches/Homebrew']:
+  file { '/usr/local':
+    ensure  => directory,
+  } ->
+  file { '/usr/local/Homebrew':
     ensure  => directory,
     owner   => $homebrew::user,
     group   => $homebrew::group,
     mode    => '0775',
     recurse => true,
-  }
-
+  } ->
   exec { 'install-homebrew':
     cwd       => '/usr/local',
     command   => "/usr/bin/su ${homebrew::user} -c '/bin/bash -o pipefail -c \"/usr/bin/curl -skSfL https://github.com/homebrew/brew/tarball/master | /usr/bin/tar xz -m --strip 1\"'",
     creates   => '/usr/local/bin/brew',
     logoutput => on_failure,
     timeout   => 0,
-    require   => File['/usr/local'],
   } ~>
   file { '/usr/local/bin/brew':
     owner => $homebrew::user,


### PR DESCRIPTION
Third and (maybe?) final way to fix #44, given homebrew now installs to `/usr/local/Homebrew` rather than parent.