### PR TITLE
Update facts to work in puppet 3 or 4

### DIFF
--- a/lib/facter/has_brew.rb
+++ b/lib/facter/has_brew.rb
@@ -1,12 +1,20 @@
-Facter.add(:has_brew) do
-  setcode do
-    "nil"
-  end
-end
+# Fact: has_brew
+#
+# Purpose: check if brew is installed
+#
+# Resolution:
+#   Tests for presence of brew, returns boolean
+#   No value set if not on Darwin
+#
+# Caveats:
+#   none
+#
+# Notes:
+#   None
 
 Facter.add(:has_brew) do
-  confine :operatingsystem => :darwin
+  confine :operatingsystem => 'Darwin'
   setcode do
-    File.exists?('/usr/local/bin/brew') or system('brew --version >/dev/null 2>&1') ? "true" : "false"
+    File.exists?('/usr/local/bin/brew') or system('brew --version >/dev/null 2>&1')
   end
 end

--- a/lib/facter/has_compiler.rb
+++ b/lib/facter/has_compiler.rb
@@ -1,21 +1,29 @@
-Facter.add(:has_compiler) do
-  setcode do
-    "nil"
-  end
-end
+# Fact: has_compiler
+#
+# Purpose: check if Xcode Command Line Tools is installed
+#
+# Resolution:
+#   Tests for presence of cc, returns boolean
+#   No value set if not on Darwin
+#
+# Caveats:
+#   none
+#
+# Notes:
+#   None
 
 Facter.add(:has_compiler) do
-  confine :operatingsystem => :darwin
+  confine :operatingsystem => 'Darwin'
   setcode do
-    File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1') ? "true" : "false"
+    File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1')
   end
 end
 
 Facter.add(:has_compiler) do
   # /usr/bin/cc exists in Mavericks, but it's not real
-  confine :operatingsystem => :darwin, :macosx_productversion_major => '10.9'
+  confine :operatingsystem => 'Darwin', :macosx_productversion_major => '10.9'
   setcode do
     (File.exists?('/Applications/Xcode.app') or File.exists?('/Library/Developer/CommandLineTools/')) and
-        (File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1')) ? "true" : "false"
+        (File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1'))
   end
 end

--- a/lib/facter/has_compiler.rb
+++ b/lib/facter/has_compiler.rb
@@ -15,15 +15,12 @@
 Facter.add(:has_compiler) do
   confine :operatingsystem => 'Darwin'
   setcode do
-    File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1')
-  end
-end
-
-Facter.add(:has_compiler) do
-  # /usr/bin/cc exists in Mavericks, but it's not real
-  confine :operatingsystem => 'Darwin', :macosx_productversion_major => '10.9'
-  setcode do
-    (File.exists?('/Applications/Xcode.app') or File.exists?('/Library/Developer/CommandLineTools/')) and
-        (File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1'))
+    # /usr/bin/cc exists in Mavericks, but it's not real
+    if Gem::Version.new(Facter.value(:macosx_productversion_major)) >= Gem::Version.new('10.9')
+      (File.exists?('/Applications/Xcode.app') or File.exists?('/Library/Developer/CommandLineTools/')) and
+          (File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1'))
+    else
+      File.exists?('/usr/bin/cc') or system('/usr/bin/xcrun -find cc >/dev/null 2>&1')
+    end
   end
 end

--- a/manifests/compiler.pp
+++ b/manifests/compiler.pp
@@ -1,6 +1,6 @@
 class homebrew::compiler {
 
-  if $::has_compiler == "true" {
+  if str2bool($::has_compiler) {
   } elsif versioncmp($::macosx_productversion_major, '10.7') < 0 {
     warning('Please install the Command Line Tools bundled with XCode manually!')
   } elsif ($homebrew::command_line_tools_package and $homebrew::command_line_tools_source) {


### PR DESCRIPTION
I'm still getting this warning in puppet 4, despite having command line tools installed.
```warning('No Command Line Tools detected and no download source set. Please set download sources or install manually.')```

I think puppet 4 is casting the strings to actual booleans and thus not matching the if == "true".
These changes should make the facts behave more predictably and work in either puppet 3 or 4.
