### PR TITLE
Update to Puppet 4 syntax

### DIFF
--- a/manifests/compiler.pp
+++ b/manifests/compiler.pp
@@ -1,7 +1,8 @@
+# Ensures a compiler is present
 class homebrew::compiler {
 
-  if str2bool($::has_compiler) {
-  } elsif versioncmp($::macosx_productversion_major, '10.7') < 0 {
+  if str2bool($facts['has_compiler']) {
+  } elsif versioncmp($facts['os']['macos']['version']['major'], '10.7') < 0 {
     warning('Please install the Command Line Tools bundled with XCode manually!')
   } elsif ($homebrew::command_line_tools_package and $homebrew::command_line_tools_source) {
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,3 +1,5 @@
+# Installs Homebrew
+
 class homebrew (
   $user,
   $command_line_tools_package = undef,
@@ -6,7 +8,7 @@ class homebrew (
   $group                      = 'admin'
 ) {
 
-  if $::operatingsystem != 'Darwin' {
+  if $facts['os']['family'] != 'Darwin' {
     fail('This Module works on Mac OSX only!')
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,26 +1,29 @@
+# Installs homebrew 
 class homebrew::install {
 
   $brew_folders = [
-                    '/usr/local',
-                    '/usr/local/bin',
-                    '/usr/local/Cellar',
-                    '/usr/local/etc',
-                    '/usr/local/Frameworks',
-                    '/usr/local/include',
-                    '/usr/local/lib',
-                    '/usr/local/lib/pkgconfig',
-                    '/usr/local/opt',
-                    '/usr/local/share',
-                    '/usr/local/share/doc',
-                    '/usr/local/share/man',
-                    '/usr/local/var',
-                  ]
+    '/usr/local',
+    '/usr/local/bin',
+    '/usr/local/Cellar',
+    '/usr/local/etc',
+    '/usr/local/Frameworks',
+    '/usr/local/include',
+    '/usr/local/lib',
+    '/usr/local/lib/pkgconfig',
+    '/usr/local/opt',
+    '/usr/local/share',
+    '/usr/local/share/doc',
+    '/usr/local/share/man',
+    '/usr/local/var',
+  ]
 
-  file { $brew_folders:
-    ensure => directory,
-    group  => $homebrew::group,
-    mode   => '0775',
-  } ->
+  $brew_folders.each |String $brew_folder| {
+    if !defined(File[$brew_folder]) {
+      file { $brew_folder:
+        ensure => directory,
+      }
+    }
+  }
   file { '/usr/local/Homebrew':
     ensure => directory,
     owner  => $homebrew::user,


### PR DESCRIPTION
Also allow for the directories to be managed elsewhere as they’re pretty common, and now passes puppet-lint.