### PR TITLE
Non root and bundler

### DIFF
--- a/lib/puppet/feature/bundled_environment.rb
+++ b/lib/puppet/feature/bundled_environment.rb
@@ -1,0 +1,6 @@
+require "puppet/util/feature"
+
+Puppet.features.add(:bundled_environment) do
+  !!(defined?(Bundler) && Bundler.respond_to?(:with_clean_env))
+end
+

--- a/lib/puppet/provider/package/brew.rb
+++ b/lib/puppet/provider/package/brew.rb
@@ -24,8 +24,24 @@ Puppet::Type.type(:package).provide(:brew, :parent => Puppet::Provider::Package)
       raise Puppet::ExecutionFailure, 'Homebrew does not support installations owned by the "root" user. Please check the permissions of /usr/local/bin/brew'
     end
 
-    super(cmd, :uid => owner, :gid => group, :combine => combine,
-          :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+    # the uid and gid can only be set if running as root
+    if Process.uid == 0
+      uid = owner
+      gid = group
+    else
+      uid = nil
+      gid = nil
+    end
+
+    if Puppet.features.bundled_environment?
+      Bundler.with_clean_env do
+        super(cmd, :uid => uid, :gid => gid, :combine => combine,
+              :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+      end
+    else
+      super(cmd, :uid => uid, :gid => gid, :combine => combine,
+            :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+    end
   end
 
   def self.instances(justme = false)

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -24,8 +24,24 @@ Puppet::Type.type(:package).provide(:brewcask, :parent => Puppet::Provider::Pack
       raise Puppet::ExecutionFailure, 'Homebrew does not support installations owned by the "root" user. Please check the permissions of /usr/local/bin/brew'
     end
 
-    super(cmd, :uid => owner, :gid => group, :combine => combine,
-          :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+    # the uid and gid can only be set if running as root
+    if Process.uid == 0
+      uid = owner
+      gid = group
+    else
+      uid = nil
+      gid = nil
+    end
+
+    if Puppet.features.bundled_environment?
+      Bundler.with_clean_env do
+        super(cmd, :uid => uid, :gid => gid, :combine => combine,
+              :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+      end
+    else
+      super(cmd, :uid => uid, :gid => gid, :combine => combine,
+            :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+    end
   end
 
   def self.instances(justme = false)

--- a/lib/puppet/provider/package/tap.rb
+++ b/lib/puppet/provider/package/tap.rb
@@ -22,8 +22,24 @@ Puppet::Type.type(:package).provide(:tap, :parent => Puppet::Provider::Package) 
       raise Puppet::ExecutionFailure, 'Homebrew does not support installations owned by the "root" user. Please check the permissions of /usr/local/bin/brew'
     end
 
-    super(cmd, :uid => owner, :gid => group, :combine => combine,
-          :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+    # the uid and gid can only be set if running as root
+    if Process.uid == 0
+      uid = owner
+      gid = group
+    else
+      uid = nil
+      gid = nil
+    end
+
+    if Puppet.features.bundled_environment?
+      Bundler.with_clean_env do
+        super(cmd, :uid => uid, :gid => gid, :combine => combine,
+              :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+      end
+    else
+      super(cmd, :uid => uid, :gid => gid, :combine => combine,
+            :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+    end
   end
 
   def execute(*args)


### PR DESCRIPTION
This PR makes it so the provider still works when you are running puppet as a non-root user and when it is being run by way of Bundler. For me this also fixes #78. 

Adding the same code to all 4 providers seemed a little odd but I didn't fully read up on #77 either. It would make sense to me to put chunks of code like 

```ruby
  def self.execute(cmd, failonfail = false, combine = false)
    owner = stat('-nf', '%Uu', '/usr/local/bin/brew').to_i
    group = stat('-nf', '%Ug', '/usr/local/bin/brew').to_i
    home  = Etc.getpwuid(owner).dir

    if owner == 0
      raise Puppet::ExecutionFailure, 'Homebrew does not support installations owned by the "root" user. Please check the permissions of /usr/local/bin/brew'
    end

    # the uid and gid can only be set if running as root
    if Process.uid == 0
      uid = owner
      gid = group
    else
      uid = nil
      gid = nil
    end

    if Puppet.features.bundled_environment?
      Bundler.with_clean_env do
        super(cmd, :uid => uid, :gid => gid, :combine => combine,
              :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
      end
    else
      super(cmd, :uid => uid, :gid => gid, :combine => combine,
            :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
    end
  end
```

into `lib/puppet/util/homebrew.rb` or similar to make things a little more DRY. If that's desired then I will happily rework this a bit.