### PR TITLE
Replace failonfail: true with :failonfail => true.

### DIFF
--- a/lib/puppet/provider/package/brew.rb
+++ b/lib/puppet/provider/package/brew.rb
@@ -96,14 +96,14 @@ Puppet::Type.type(:package).provide(:brew, :parent => Puppet::Provider::Package)
 
     begin
       Puppet.debug "Looking for #{resource_name} package..."
-      execute([command(:brew), :info, resource_name], failonfail: true)
+      execute([command(:brew), :info, resource_name], :failonfail => true)
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not find package: #{resource_name}"
     end
 
     begin
       Puppet.debug "Package found, installing..."
-      output = execute([command(:brew), :install, resource_name, *install_options], failonfail: true)
+      output = execute([command(:brew), :install, resource_name, *install_options], :failonfail => true)
 
       if output =~ /sha256 checksum/
         Puppet.debug "Fixing checksum error..."
@@ -120,7 +120,7 @@ Puppet::Type.type(:package).provide(:brew, :parent => Puppet::Provider::Package)
 
     begin
       Puppet.debug "Uninstalling #{resource_name}"
-      execute([command(:brew), :uninstall, resource_name], failonfail: true)
+      execute([command(:brew), :uninstall, resource_name], :failonfail => true)
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not uninstall package: #{detail}"
     end
@@ -131,7 +131,7 @@ Puppet::Type.type(:package).provide(:brew, :parent => Puppet::Provider::Package)
 
     begin
       Puppet.debug "Upgrading #{resource_name}"
-      execute([command(:brew), :upgrade, resource_name], failonfail: true)
+      execute([command(:brew), :upgrade, resource_name], :failonfail => true)
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not upgrade package: #{detail}"
     end

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -96,14 +96,14 @@ Puppet::Type.type(:package).provide(:brewcask, :parent => Puppet::Provider::Pack
 
     begin
       Puppet.debug "Looking for #{resource_name} package..."
-      execute([command(:brew), :cask, :info, resource_name], failonfail: true)
+      execute([command(:brew), :cask, :info, resource_name], :failonfail => true)
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not find package: #{resource_name}"
     end
 
     begin
       Puppet.debug "Package found, installing..."
-      output = execute([command(:brew), :cask, :install, resource_name, *install_options], failonfail: true)
+      output = execute([command(:brew), :cask, :install, resource_name, *install_options], :failonfail => true)
 
       if output =~ /sha256 checksum/
         Puppet.debug "Fixing checksum error..."
@@ -120,7 +120,7 @@ Puppet::Type.type(:package).provide(:brewcask, :parent => Puppet::Provider::Pack
 
     begin
       Puppet.debug "Uninstalling #{resource_name}"
-      execute([command(:brew), :cask, :uninstall, resource_name], failonfail: true)
+      execute([command(:brew), :cask, :uninstall, resource_name], :failonfail => true)
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not uninstall package: #{detail}"
     end

--- a/lib/puppet/provider/package/homebrew.rb
+++ b/lib/puppet/provider/package/homebrew.rb
@@ -97,10 +97,10 @@ Puppet::Type.type(:package).provide(:homebrew, :parent => Puppet::Provider::Pack
     begin
       begin
         Puppet.debug "Looking for #{resource_name} package on brew..."
-        output = execute([command(:brew), :info, resource_name], failonfail: true)
+        output = execute([command(:brew), :info, resource_name], :failonfail => true)
 
         Puppet.debug "Package found, installing..."
-        output = execute([command(:brew), :install, resource_name, *install_options], failonfail: true)
+        output = execute([command(:brew), :install, resource_name, *install_options], :failonfail => true)
 
         if output =~ /sha256 checksum/
           Puppet.debug "Fixing checksum error..."
@@ -109,10 +109,10 @@ Puppet::Type.type(:package).provide(:homebrew, :parent => Puppet::Provider::Pack
         end
       rescue Puppet::ExecutionFailure
         Puppet.debug "Package #{resource_name} not found on Brew. Trying BrewCask..."
-        execute([command(:brew), :cask, :info, resource_name], failonfail: true)
+        execute([command(:brew), :cask, :info, resource_name], :failonfail => true)
 
         Puppet.debug "Package found on brewcask, installing..."
-        output = execute([command(:brew), :cask, :install, resource_name, *install_options], failonfail: true)
+        output = execute([command(:brew), :cask, :install, resource_name, *install_options], :failonfail => true)
 
         if output =~ /sha256 checksum/
           Puppet.debug "Fixing checksum error..."
@@ -130,10 +130,10 @@ Puppet::Type.type(:package).provide(:homebrew, :parent => Puppet::Provider::Pack
 
     begin
       Puppet.debug "Uninstalling #{resource_name}"
-      execute([command(:brew), :uninstall, resource_name], failonfail: true)
+      execute([command(:brew), :uninstall, resource_name], :failonfail => true)
     rescue Puppet::ExecutionFailure
       begin
-        execute([command(:brew), :cask, :uninstall, resource_name], failonfail: true)
+        execute([command(:brew), :cask, :uninstall, resource_name], :failonfail => true)
       rescue Puppet::ExecutionFailure => detail
         raise Puppet::Error, "Could not uninstall package: #{detail}"
       end

--- a/lib/puppet/provider/package/tap.rb
+++ b/lib/puppet/provider/package/tap.rb
@@ -57,7 +57,7 @@ Puppet::Type.type(:package).provide(:tap, :parent => Puppet::Provider::Package) 
 
     begin
       Puppet.debug "Tapping #{resource_name}"
-      execute([command(:brew), :tap, resource_name, *install_options], failonfail: true)
+      execute([command(:brew), :tap, resource_name, *install_options], :failonfail => true)
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not tap resource: #{detail}"
     end
@@ -68,7 +68,7 @@ Puppet::Type.type(:package).provide(:tap, :parent => Puppet::Provider::Package) 
 
     begin
       Puppet.debug "Untapping #{resource_name}"
-      execute([command(:brew), :untap, resource_name], failonfail: true)
+      execute([command(:brew), :untap, resource_name], :failonfail => true)
     rescue Puppet::ExecutionFailure => detail
       raise Puppet::Error, "Could not untap resource: #{detail}"
     end


### PR DESCRIPTION
This resolves the syntax errors thrown by Ruby version 1.8.3.

The other option was to drop the failonfail options all together because they default to true when no other options are provided.