### PR TITLE
Remove check for homebrew- on returned Taps as brew format change.

### DIFF
--- a/lib/puppet/provider/package/tap.rb
+++ b/lib/puppet/provider/package/tap.rb
@@ -82,8 +82,6 @@ Puppet::Type.type(:package).provide(:tap, :parent => Puppet::Provider::Package) 
       output = execute([command(:brew), :tap])
       output.each_line do |line|
         line.chomp!
-        next unless [resource_name, resource_name.gsub('homebrew-', '')].include?(line.downcase)
-
         return { :name => line, :ensure => 'present', :provider => 'tap' }
       end
     rescue Puppet::ExecutionFailure => detail


### PR DESCRIPTION
Cask listing has changed and as result, the Homebrew module add's the same tap on every run.

The following change correctly returns tap's to be processed by the module 
