### PR TITLE
Use 'at' symbol to specify versions passed through ensure

### DIFF
--- a/lib/puppet/provider/package/brew.rb
+++ b/lib/puppet/provider/package/brew.rb
@@ -81,7 +81,7 @@ Puppet::Type.type(:package).provide(:brew, :parent => Puppet::Provider::Package)
     when true, false, Symbol
       resource_name
     else
-      "#{resource_name}-#{should}"
+      "#{resource_name}@#{should}"
     end
   end
 

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -81,7 +81,7 @@ Puppet::Type.type(:package).provide(:brewcask, :parent => Puppet::Provider::Pack
     when true, false, Symbol
       resource_name
     else
-      "#{resource_name}-#{should}"
+      "#{resource_name}@#{should}"
     end
   end
 

--- a/lib/puppet/provider/package/homebrew.rb
+++ b/lib/puppet/provider/package/homebrew.rb
@@ -81,7 +81,7 @@ Puppet::Type.type(:package).provide(:homebrew, :parent => Puppet::Provider::Pack
     when true, false, Symbol
       resource_name
     else
-      "#{resource_name}-#{should}"
+      "#{resource_name}@#{should}"
     end
   end
 


### PR DESCRIPTION
https://docs.brew.sh/Versions mentions that versions are specified using an '@' symbol
and do not include the patch version. Hence, in order to support versioning through
the ensure block, we shouldn't use a hyphen but the '@' symbol.

Please let me know if I've missed/misunderstood anything and should go a different way of tackling this :)