### PR TITLE
package: hard-code cwd to /tmp to execute brew

### DIFF
--- a/lib/puppet/provider/package/brew.rb
+++ b/lib/puppet/provider/package/brew.rb
@@ -43,11 +43,15 @@ Puppet::Type.type(:package).provide(:brew, :parent => Puppet::Provider::Package)
     if Puppet.features.bundled_environment?
       Bundler.with_clean_env do
         super(cmd, :uid => uid, :gid => gid, :combine => combine,
-              :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+              :custom_environment => { 'HOME' => home },
+              :cwd => '/tmp',
+              :failonfail => failonfail)
       end
     else
       super(cmd, :uid => uid, :gid => gid, :combine => combine,
-            :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+            :custom_environment => { 'HOME' => home },
+            :cwd => '/tmp',
+            :failonfail => failonfail)
     end
   end
 

--- a/lib/puppet/provider/package/brewcask.rb
+++ b/lib/puppet/provider/package/brewcask.rb
@@ -43,11 +43,15 @@ Puppet::Type.type(:package).provide(:brewcask, :parent => Puppet::Provider::Pack
     if Puppet.features.bundled_environment?
       Bundler.with_clean_env do
         super(cmd, :uid => uid, :gid => gid, :combine => combine,
-              :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+              :custom_environment => { 'HOME' => home },
+              :cwd => '/tmp',
+              :failonfail => failonfail)
       end
     else
       super(cmd, :uid => uid, :gid => gid, :combine => combine,
-            :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+            :custom_environment => { 'HOME' => home },
+            :cwd => '/tmp',
+            :failonfail => failonfail)
     end
   end
 

--- a/lib/puppet/provider/package/homebrew.rb
+++ b/lib/puppet/provider/package/homebrew.rb
@@ -43,11 +43,15 @@ Puppet::Type.type(:package).provide(:homebrew, :parent => Puppet::Provider::Pack
     if Puppet.features.bundled_environment?
       Bundler.with_clean_env do
         super(cmd, :uid => uid, :gid => gid, :combine => combine,
-              :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+              :custom_environment => { 'HOME' => home },
+              :cwd => '/tmp',
+              :failonfail => failonfail)
       end
     else
       super(cmd, :uid => uid, :gid => gid, :combine => combine,
-            :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+            :custom_environment => { 'HOME' => home },
+            :cwd => '/tmp',
+            :failonfail => failonfail)
     end
   end
 

--- a/lib/puppet/provider/package/tap.rb
+++ b/lib/puppet/provider/package/tap.rb
@@ -41,11 +41,15 @@ Puppet::Type.type(:package).provide(:tap, :parent => Puppet::Provider::Package) 
     if Puppet.features.bundled_environment?
       Bundler.with_clean_env do
         super(cmd, :uid => uid, :gid => gid, :combine => combine,
-              :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+              :custom_environment => { 'HOME' => home },
+              :cwd => '/tmp',
+              :failonfail => failonfail)
       end
     else
       super(cmd, :uid => uid, :gid => gid, :combine => combine,
-            :custom_environment => { 'HOME' => home }, :failonfail => failonfail)
+            :custom_environment => { 'HOME' => home },
+            :cwd => '/tmp',
+            :failonfail => failonfail)
     end
   end
 


### PR DESCRIPTION
If cwd is a directory the brew user can't write to
(e.g. if running with bolt as root where the working
directory is a private subdirectory under /tmp) brew
fails to run.

Resolves #101

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>