### PR TITLE
Don't automatically create numbered manpage folders

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -67,14 +67,6 @@ class homebrew::install {
     "${brew_root}/share/doc",
     "${brew_root}/share/info",
     "${brew_root}/share/man",
-    "${brew_root}/share/man1",
-    "${brew_root}/share/man2",
-    "${brew_root}/share/man3",
-    "${brew_root}/share/man4",
-    "${brew_root}/share/man5",
-    "${brew_root}/share/man6",
-    "${brew_root}/share/man7",
-    "${brew_root}/share/man8",
   ])
 
   file { $brew_folders:


### PR DESCRIPTION
The Puppet Homebrew module creates `/opt/homebrew/share/man[1-8]` folders, but when I run `brew cleanup`, it deletes them:
```console
$ brew cleanup
Pruned 0 symbolic links and 8 directories from /opt/homebrew
```
Since Homebrew doesn't expect those folders to be present, AFAIK there's no need to create them, so this PR removes their Puppet resource definitions.
