### PR TITLE
fix puppet 8 compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@ class homebrew (
   $multiuser                  = false,
 ) {
 
-  if $::operatingsystem != 'Darwin' {
+  if fact('os.family') != 'Darwin' {
     fail('This Module works on Mac OSX only!')
   }
 


### PR DESCRIPTION
fixes
```
2025-05-07 20:39:22 -0500 Puppet (err): Evaluation Error: Unknown variable: '::operatingsystem'.
```